### PR TITLE
Changed prefix to query_string

### DIFF
--- a/src/components/SearchBox.vue
+++ b/src/components/SearchBox.vue
@@ -95,7 +95,7 @@
                         fun : 'filter',
                         args : ['bool', arg => {
                             this.mutableField.forEach(attr => {
-                                arg[this.fun]('prefix', attr, value);
+                                arg[this.fun]('query_string', attr, value);
                             });
                             return arg;
                         }]

--- a/src/lib/Generics.js
+++ b/src/lib/Generics.js
@@ -274,7 +274,7 @@ export default {
 			// Feed the request
 			let _body = Bodybuilder().size(size);
 			fields.forEach(field => {
-				_body[fun]('prefix', field, value);
+				_body[fun]('query_string', field, value);
 			});
 
 			// Don't fetch items already selected


### PR DESCRIPTION
This SHOULD allow you to query ES using search terms with spaces in the middle using an analyser, provided you list your field as query? It does require a "text" field. This is untested but I think it should work if my query building knowledge is correct?